### PR TITLE
fix: active navbar and gopher con map

### DIFF
--- a/src/pages/Team.vue
+++ b/src/pages/Team.vue
@@ -63,7 +63,7 @@ export default class Team extends Vue {
   }
 
   public mounted () {
-    this.tabs = this.menu.filter((item) => item.name === 'Team')[0].children as MenuItem[];
+    this.tabs = this.menu.filter((item) => item.name === 'Staff')[0].children as MenuItem[];
   }
 
   private isInApp (): boolean {

--- a/src/pages/Traffic.vue
+++ b/src/pages/Traffic.vue
@@ -7,7 +7,7 @@
       GIS NTU Convention Center<br/>
       Taipei City, Da’an District, Section 4, Roosevelt Rd, No.85 B1
     </p>
-    <gophercon-map width="100%" height="650px" />
+    <gopher-con-map width="100%" height="650px" />
     <div class="traffic-flow">
       <img src="@/assets/images/traffic-flow.png" alt="">
     </div>

--- a/src/router.ts
+++ b/src/router.ts
@@ -84,7 +84,7 @@ export const routes = [
   },
   {
     path: '/team',
-    name: 'Team',
+    name: 'Staff',
     component: Team,
     redirect: '/team/staff',
     meta: {
@@ -115,7 +115,7 @@ export const routes = [
   },
   {
     path: '/sponsor',
-    name: 'SponsorRedirect',
+    name: 'Sponsor',
     redirect: '/team/sponsor',
     meta: {
       label: '贊助',


### PR DESCRIPTION
This fixes the missing active "underline" not shown on the sponsor page:

![image](https://user-images.githubusercontent.com/667169/74952412-2d6ad080-543b-11ea-9743-cafad2b19c2f.png)


, and the missing GopherConMap component:

