### PR TITLE
Disable internal cfp pages and redirect to papercall

### DIFF
--- a/src/components/CFP/Banner.vue
+++ b/src/components/CFP/Banner.vue
@@ -42,9 +42,9 @@
           <p class="code font-black font-italic">future</p>
           <p class="code font-black font-italic">programmer</p>
           <div class="board">
-            <h1 class="date font-black">3/28（六）</h1>
-            <h3>中央研究院</h3>
-            <h2 class="font-bold">人文社會科學館</h2>
+            <h1 class="date font-black">9/19（六）</h1>
+            <h3>集思台大會議中心</h3>
+            <h2 class="font-bold">國際會議廳</h2>
           </div>
         </div>
       </div>

--- a/src/pages/CFP.vue
+++ b/src/pages/CFP.vue
@@ -116,7 +116,7 @@ export default class CFP extends Vue {
     head.title('Call for Paper｜稿件徵求中！');
     head.ogTitle('Call for Paper｜稿件徵求中！');
     head.ogDescription('GopherCon 2020 邀請身為 Golang 使用者的你，向大家分享您的經驗與技術，期待您能在演講桌前，與我們一起 #define golang。');
-    head.ogUrl('https://golang.tw/2020/cfp/');
+    head.ogUrl('https://www.papercall.io/gophercon-2020-taiwan');
     head.ogImage('https://golang.tw/2020/img/cfp-og.png');
   }
 }

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -23,7 +23,7 @@
       </div>
       <div class="right-container">
         <p class="kktix">
-          <a href="https://gophercon.golang.tw/2020/cfp" target="_blank" rel="noopener">
+          <a href="https://www.papercall.io/gophercon-2020-taiwan" target="_blank" rel="noopener">
             <span>會議徵稿</span>
           </a>
           <a href="https://bit.ly/donategophercon2020" target="_blank" rel="noopener">

--- a/src/router.ts
+++ b/src/router.ts
@@ -121,14 +121,6 @@ export const routes = [
       label: '贊助',
       menuItem: true
     }
-  },
-  {
-    path: '/cfp',
-    name: 'CFP',
-    component: CFP,
-    meta: {
-      menuItem: false
-    }
   }
 ];
 
@@ -137,16 +129,7 @@ const router = new Router({
   base: '/2020/',
   routes,
   scrollBehavior (to, from, savedPosition) {
-    if (to.name === 'CFP' && to.query.popUp && to.hash) {
-      const target = document.querySelector(`.popup-content>${to.hash}`) as HTMLElement;
-      const popUp = document.querySelector(`.popup-content`) as HTMLElement;
-      const popupPadding = 24;
-
-      return window.scrollTo({
-        top: target.offsetTop + popUp.offsetTop - popupPadding,
-        behavior: 'smooth'
-      });
-    } else if (to.hash) {
+    if (to.hash) {
       const target = document.querySelector(to.hash) as HTMLElement;
 
       return window.scrollTo({


### PR DESCRIPTION
1. 移除內部 route  /2020/cfp
2. 轉址到 https://www.papercall.io/gophercon-2020-taiwan
3. 仍然保留 CFP components，如果需要可以加回來