### PR TITLE
fix(Home): add CFP link in info section

### DIFF
--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -26,9 +26,9 @@
           <span class="inner font-black">關於 About</span>
         </h1>
         <p class="content">Gopher Conference Taiwan 自 2020 年發起，由 Golang Taipei 社群舉辦，長期投身推廣 Golang 程式語言與相關技術，希望引領更多軟體從業人員使用 Golang 語言，對 Golang 有興趣的朋友可以一同參與社群。</p>
-        <p class="content">GopherCon TW 2020 邀請身為 Golang 使用者的你，向大家分享您的經驗與技術，期待您能在演講桌前，與我們一起 have fun with golang</a>。</p>
+        <p class="content">GopherCon TW 2020 邀請身為 Golang 使用者的你，向大家分享您的經驗與技術，期待您能在演講桌前，與我們一起 <a href="https://www.papercall.io/gophercon-2020-taiwan" target="_blank" rel="noopener">have fun with golang</a>。</p>
         <p class="content">Gopher Conference Taiwan is a conference held by Golang Taipei User Group since 2020. It's aim is promoting Go language and Go's communities. The event is held with talks, sponsor, and communities booths. Whoever you are a Golang coder, open source promoter, or even a newcomer, we sincerely welcome you to be part of GopherCon TW!</p>
-        <p class="content">Call for Papers! We are looking for talks in Golang related areas. Join us and have fun with golang</a> by sharing your Golang experiences!</p>
+        <p class="content">Call for Papers! We are looking for talks in Golang related areas. Join us and <a href="https://www.papercall.io/gophercon-2020-taiwan" target="_blank" rel="noopener">have fun with golang</a> by sharing your Golang experiences!</p>
       </div>
       <div class="spotlight sharp-back-taton" ref="gopherconTatonMask">
         <h1 class="title has-prefix-icon">


### PR DESCRIPTION
The `<a>` tag is missing, add it back.