### PR TITLE
Let logo in mobile view position absolute

### DIFF
--- a/src/components/LogoTop.vue
+++ b/src/components/LogoTop.vue
@@ -52,4 +52,16 @@
     }
   }
 }
+
+@media (max-width: 480px) and (max-height: 1024px) {
+  .logo-top {
+    position: absolute;
+  }
+}
+
+@media (max-height: 1024px) {
+  .logo-top {
+    position: absolute;
+  }
+}
 </style>


### PR DESCRIPTION
Let GopherCon 2020 logo hide when scroll down.